### PR TITLE
Add Class Commons support

### DIFF
--- a/classic.lua
+++ b/classic.lua
@@ -65,4 +65,27 @@ function Object:__call(...)
 end
 
 
+if _G.common_class then
+	local common = {}
+
+	function common.class(_, definition, superclass)
+		superclass = superclass or Object
+
+		local class = superclass:extend()
+		for i, v in pairs(definition) do
+			class[i] = v
+		end
+
+		class.new = definition.init or superclass.new or superclass.init
+
+		return class
+	end
+
+	function common.instance(class, ...)
+		return class(...)
+	end
+
+	_G.common = common
+end
+
 return Object


### PR DESCRIPTION
Here's a small class commons implementation that passes all class commons tests.

EDIT: I should probably add some context:

[Class Commons](https://github.com/bartbes/Class-Commons/) is a project to allow libraries to write against a common class interface. That way, the author can use classes in their libraries, yet the user can use those classes with their library of choice. Meaning they can subclass your (library) classes, or vice versa, they can instantiate them as they would any other classes, you can instantiate their classes, and all that goodness.

I wrote this because I saw [a post on the love forums](https://love2d.org/forums/viewtopic.php?t=85281) of someone wanting to use classic with HC, which supports Class Commons.